### PR TITLE
feat: Port LLM agent framework from Common Lisp to Clojure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,11 @@ __pycache__
 
 
 .codegpt
+
+# Clojure/Java specific
+target/
+*.jar
+*.class
+.cpcache/
+.nrepl-port
+pom.xml

--- a/README.md
+++ b/README.md
@@ -33,3 +33,48 @@ Run in your Lisp REPL:
   (ql:quickload :cl-llm-agent)
   (asdf:test-system :cl-llm-agent)
 ```
+## Clojure Version
+
+This repository also contains a Clojure port of the Common Lisp LLM agent framework.
+The Clojure source files (`.clj`) are located in the root directory and mirror the structure of the Lisp files.
+
+### Dependencies
+
+The Clojure version uses `deps.edn` for dependency management. Key dependencies include:
+- `org.clojure/clojure`
+- `org.clojure/data.json`
+
+### Running the Clojure Code
+
+#### Unit Tests
+
+To run the automated unit tests (defined in `tests/tests.clj`):
+```bash
+clojure -M:test
+```
+
+#### Manual Test Script
+
+A manual test script is available at `test.clj`. You can run its `-main` function using the Clojure CLI:
+```bash
+clojure -M -m clj-llm-agent.test-script
+```
+This script demonstrates creating an agent, interacting with it (using placeholder LLM responses), and managing context.
+
+#### REPL Usage
+
+You can also explore the framework interactively in a REPL:
+```bash
+clj # or: clojure
+```
+Then, require namespaces and call functions as needed. For example:
+```clojure
+(require '[clj-llm-agent.context :as ctx]
+         '[clj-llm-agent.agent-generic :as generic]
+         '[clj-llm-agent.agent-gemini]) ; Load Gemini agent specifics
+
+(def my-ctx (ctx/make-context))
+(ctx/context-set my-ctx :user "Test User")
+(def my-agent (generic/make-agent :gemini-agent {:name "ClojureAgent" :context my-ctx}))
+(generic/agent-converse my-agent "Hello, agent!")
+```

--- a/agent_gemini.clj
+++ b/agent_gemini.clj
@@ -1,0 +1,38 @@
+(ns clj-llm-agent.agent-gemini
+  (:require [clj-llm-agent.agent-generic :as generic]))
+
+;; The make-agent function in agent-generic is used to create agents of different types.
+;; We define the behavior for :gemini-agent by implementing the agent-llm-call multimethod.
+
+(defmethod generic/agent-llm-call :gemini-agent
+  [agent prompt]
+  (when generic/*agent-verbose*
+    (println "[gemini-agent] LLM Call. Agent:" (:name agent) "Prompt:" prompt))
+  ;; Placeholder for actual Gemini API call
+  ;; In a real implementation, this would involve:
+  ;; 1. Setting up a Gemini API client (e.g., using an HTTP library like clj-http).
+  ;; 2. Formatting the request according to Gemini API specs.
+  ;; 3. Making the API call.
+  ;; 4. Processing the response.
+  (println "--- Gemini LLM Call (Placeholder) ---")
+  (println "Prompt received by Gemini agent:")
+  (println prompt)
+  (println "--- End Gemini LLM Call ---")
+  ;; Returning a mock JSON response structure that agent-converse can parse
+  ;; This mock response simulates the LLM suggesting a tool call.
+  (str "```json\n"
+       "{\n"
+       "  \"actions\": [\n"
+       "    {\n"
+       "      \"action\": \"tool-read-file\",\n"
+       "      \"parameters\": [\"example.txt\"]\n"
+       "    }\n"
+       "  ]\n"
+       "}\n"
+       "```"))
+
+;; Example of how to create a gemini-agent instance:
+;; (generic/make-agent :gemini-agent {:name "MyGeminiAgent" :context (ctx/make-context)})
+;;
+;; The :gemini-agent keyword will dispatch to the implementation of
+;; generic/agent-llm-call defined above.

--- a/agent_generic.clj
+++ b/agent_generic.clj
@@ -1,0 +1,121 @@
+(ns clj-llm-agent.agent-generic
+  (:require [clojure.data.json :as json]
+            [clojure.string :as str]
+            [clj-llm-agent.context :as ctx]
+            [clj-llm-agent.tools :as tools]))
+
+;; JSON parsing utilities
+(defn parse-json [json-string]
+  (try
+    (json/read-str json-string :key-fn keyword)
+    (catch Exception _ nil))) ; Return nil on failure, like the Lisp version
+
+(defn safe-parse-json [json-string]
+  (let [parsed (parse-json json-string)]
+    (if parsed
+      parsed
+      (throw (ex-info (str "Failed to parse JSON: " json-string) {:json-string json-string})))))
+
+(defn strip-markdown-json [text]
+  (let [trimmed (str/trim text)
+        json-block-regex #"```json\s*([\s\S]+?)\s*```"]
+    (if-let [match (re-find json-block-regex trimmed)]
+      (second match)
+      trimmed)))
+
+;; Base agent record
+;; Clojure's defrecord creates a type with named fields, suitable for representing agents.
+;; It also generates a constructor function (->BaseAgent) and field accessors.
+(defrecord BaseAgent [name context tools agent-type]) ; Added agent-type for multimethod dispatch
+
+;; LLM back-end multimethod
+;; Dispatches on the :agent-type field of the agent record.
+(defmulti agent-llm-call :agent-type)
+
+;; Default implementation for agent-llm-call (can be overridden by specific agent types)
+(defmethod agent-llm-call :default [agent prompt]
+  (throw (ex-info (str "LLM call not implemented for agent type: " (:agent-type agent))
+                  {:agent agent :prompt prompt})))
+
+;; Agent factory function
+(defn make-agent
+  "Constructs an agent of a given type with initial properties.
+  Example: (make-agent :gemini-agent {:name "MyGemini" :context my-ctx})"
+  [agent-type initargs]
+  (let [context (or (:context initargs) (ctx/make-context))
+        tools-map (or (:tools initargs) {})] ; Tools specific to this agent instance (if any)
+    (->BaseAgent (:name initargs) context tools-map agent-type)))
+
+
+;; Dynamic var for verbose output
+(def ^:dynamic *agent-verbose* false)
+
+;; Agent conversation logic
+(defn agent-converse [agent user-input]
+  (when *agent-verbose*
+    (println "[agent-converse] input:" user-input)
+    (ctx/display-context (:context agent) "Context start:"))
+
+  (let [tools-info (with-out-str
+                     (println "tools:")
+                     (doseq [t (tools/list-tools)]
+                       (println (str "  " (:name t) ": " (:description t)))))
+        prompt (str tools-info "\n"
+                    "User Input: " user-input "\n\n"
+                    "If using tools, respond in JSON.")
+        ;; Placeholder for raw LLM call - this will be specialized by agent type
+        raw-llm-response (agent-llm-call agent prompt)
+        
+        ;; Ensure raw-llm-response is a string before stripping
+        clean-json-text (if (string? raw-llm-response)
+                           (strip-markdown-json raw-llm-response)
+                           (throw (ex-info "LLM response was not a string." {:response raw-llm-response})))
+        parsed-response (safe-parse-json clean-json-text)
+        
+        ;; The Lisp code expects actions to be a list (vector in Clojure),
+        ;; even if there's a single action map.
+        actions (let [actions-field (:actions parsed-response)]
+                  (cond
+                    (vector? actions-field) actions-field
+                    (map? actions-field) [actions-field] ; Wrap single map in a vector
+                    (map? parsed-response) [parsed-response] ; If top-level is the action
+                    :else []))]
+
+    (when *agent-verbose*
+      (println "[agent-converse] raw-llm-response:" raw-llm-response)
+      (println "[agent-converse] clean-json-text:" clean-json-text)
+      (println "[agent-converse] parsed-response:" parsed-response)
+      (println "[agent-converse] actions:" actions))
+
+    (loop [remaining-actions actions
+           prev-result nil
+           final-results []]
+      (if-let [action (first remaining-actions)]
+        (let [action-name (keyword (:action action)) ; Ensure action name is a keyword if tools are registered with keywords
+              action-params (:parameters action)
+              processed-params (map (fn [p] (if (= p "PREV_RESULT") prev-result p))
+                                    (if (sequential? action-params) action-params []))]
+          (when *agent-verbose*
+            (println "[agent-converse] Executing action:" action-name "with params:" processed-params))
+          
+          (try
+            (let [current-result (apply tools/execute-tool (name action-name) processed-params)]
+              (recur (rest remaining-actions) current-result (conj final-results current-result)))
+            (catch Exception e
+              (when *agent-verbose*
+                (println "[agent-converse] Error executing action:" action-name e))
+              (recur (rest remaining-actions) (str "Error executing " action-name ": " (.getMessage e)) (conj final-results (str "Error executing " action-name))))))
+        ;; When no more actions, decide what to return
+        (if (seq final-results)
+            (str/join "\n" final-results) ; Return all results or just the last one? Lisp returns `prev`
+            (if (string? raw-llm-response) raw-llm-response (str raw-llm-response)))))))
+
+
+;; The define-agent macro from Lisp is more complex due to CLOS.
+;; For Clojure, records and multimethods provide much of the same functionality.
+;; A simple version might just be a helper for creating agent factory functions
+;; or ensuring consistent record creation, but `make-agent` already handles this.
+;; If specific agent types need more complex setup, they can have their own
+;; constructor functions.
+;; For now, we'll omit a direct Clojure `define-agent` macro, as `make-agent`
+;; combined with `defrecord` and `defmulti` covers the core needs.

--- a/context.clj
+++ b/context.clj
@@ -1,0 +1,29 @@
+(ns clj-llm-agent.context
+  (:require [clojure.pprint :as pp]))
+
+(defn make-context
+  "Creates a new agent context (an atom containing an empty map)."
+  []
+  (atom {}))
+
+(defn context-set
+  "Sets key to value in the context (atom holding a map)."
+  [ctx key value]
+  (swap! ctx assoc key value))
+
+(defn context-get
+  "Retrieves the value for key from the context (atom holding a map)."
+  [ctx key]
+  (get @ctx key))
+
+(defn context-remove
+  "Removes key from the context (atom holding a map)."
+  [ctx key]
+  (swap! ctx dissoc key))
+
+(defn display-context
+  "Pretty prints the contents of the context."
+  [ctx &optional message]
+  (when message
+    (println message))
+  (pp/pprint @ctx))

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,9 @@
+{:paths ["." "tests"] ; Assuming .clj files are in root, and tests are in tests/
+
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        org.clojure/data.json {:mvn/version "2.4.0"}}
+
+ :aliases
+ {:test {:extra-paths ["tests"]
+         :extra-deps {org.clojure/test {:mvn/version "1.0.1"}} ; or a specific test runner
+         :main-opts ["-m" "clojure.main" "-e" "(require 'clj-llm-agent.tests) (clojure.test/run-tests 'clj-llm-agent.tests)"]}}}

--- a/package.clj
+++ b/package.clj
@@ -1,0 +1,6 @@
+(ns clj-llm-agent.core
+  (:doc "Core namespace for the Clojure LLM Agent framework."))
+
+;; Later, we will add :require clauses for other namespaces
+;; and ensure necessary functions and macros are public.
+;; For now, this defines the main namespace.

--- a/test.clj
+++ b/test.clj
@@ -1,0 +1,74 @@
+(ns clj-llm-agent.test-script
+  (:require [clj-llm-agent.context :as ctx]
+            [clj-llm-agent.agent-generic :as generic]
+            [clj-llm-agent.tools :as tools]
+            ;; Require agent-gemini to ensure its multimethods are loaded
+            [clj-llm-agent.agent-gemini]))
+
+
+(defn -main [& args]
+  (println "--- Clojure LLM Agent Test Script ---")
+
+  ;; 1. Create a context object
+  (def my-context (ctx/make-context))
+  (println "\n--- Initial Context ---")
+  (ctx/display-context my-context "Initial MyContext:")
+
+  ;; 2. Set some initial data in the context
+  (ctx/context-set my-context :current-task "researching Clojure libraries")
+  (ctx/context-set my-context :user-location "Remote")
+  (println "\n--- Context after setting initial data ---")
+  (ctx/display-context my-context "MyContext after initial sets:")
+
+  ;; 3. Create a Gemini Agent and pass the context
+  (def my-agent (generic/make-agent :gemini-agent
+                                    {:name "TestGeminiAgent"
+                                     :context my-context}))
+  (println "\n--- Agent Created ---")
+  (println "Agent Name:" (:name my-agent))
+  (println "Agent Type:" (:agent-type my-agent))
+
+  ;; 4. Try extracting context from agent and display
+  (let [agent-ctx (:context my-agent)]
+    (ctx/display-context agent-ctx "Context fetched from agent:"))
+  (ctx/display-context my-context "Original my-context (should be the same object for atom-based context):")
+
+  (println "\n--- Agent Conversation (Verbose Mode) ---")
+  (binding [generic/*agent-verbose* true]
+    (println "\n--- Conversation 1: Requesting file read (mocked tool call) ---")
+    (let [response1 (generic/agent-converse my-agent "Please read the file 'example.txt'.")]
+      (println "\nAgent Response 1:" response1)
+      (ctx/display-context my-context "Context after conversation 1:"))
+
+    (println "\n--- Conversation 2: Generic query (mocked LLM response) ---")
+    (let [response2 (generic/agent-converse my-agent "What are the latest AI advancements?")]
+      (println "\nAgent Response 2:" response2)
+      (ctx/display-context my-context "Context after conversation 2:")))
+
+  (println "\n--- Agent Conversation (Normal Mode) ---")
+  (binding [generic/*agent-verbose* false]
+    (println "\n--- Conversation 3: Summarize text (mocked tool call via mocked LLM) ---")
+    ;; The Gemini placeholder returns a tool call for tool-read-file.
+    ;; To test tool-summarize, we would need to adjust the mock or have a more sophisticated mock LLM.
+    ;; For now, this will again trigger the mocked tool-read-file.
+    (let [response3 (generic/agent-converse my-agent "Summarize the content of 'test.txt'.")]
+      (println "\nAgent Response 3:" response3)
+      (ctx/display-context my-context "Context after conversation 3:")))
+
+  ;; 5. Accessing context directly
+  (println "\n--- Direct Context Access ---")
+  (println "Current Task from Context:" (ctx/context-get my-context :current-task))
+
+  ;; 6. Example of setting context from outside
+  (ctx/context-set my-context :user-language-preference "Clojure")
+  (println "\n--- Context after setting language preference ---")
+  (ctx/display-context my-context "MyContext after setting language preference:")
+
+  (println "\n--- Listing Registered Tools ---")
+  (doseq [tool (tools/list-tools)]
+    (println tool))
+
+  (println "\n--- End of Test Script ---"))
+
+;; To run this test script (e.g., from a REPL or using clojure -M -m clj-llm-agent.test-script):
+;; (clj-llm-agent.test-script/-main)

--- a/tests/tests.clj
+++ b/tests/tests.clj
@@ -1,0 +1,51 @@
+(ns clj-llm-agent.tests
+  (:require [clojure.test :refer :all]
+            [clj-llm-agent.context :as ctx]
+            [clj-llm-agent.tools :as tools]))
+
+(deftest context-set-get-remove-test
+  (let [test-ctx (ctx/make-context)]
+    (testing "Setting and getting a value"
+      (ctx/context-set test-ctx :foo 42)
+      (is (= (ctx/context-get test-ctx :foo) 42) "Value should be retrieved correctly."))
+    (testing "Removing a value"
+      (ctx/context-remove test-ctx :foo)
+      (is (nil? (ctx/context-get test-ctx :foo)) "Value should be nil after removal."))))
+
+(deftest tool-registration-and-execution-test
+  (let [dummy-tool-name "dummy-multiply-tool"
+        original-registry-value (atom nil)] ; To store any pre-existing tool with the same name
+
+    (testing "Registering and executing a new tool"
+      ;; Store and remove if a tool with this name already exists, for test idempotency
+      (when (get @tools/tool-registry dummy-tool-name)
+        (reset! original-registry-value (get @tools/tool-registry dummy-tool-name))
+        (swap! tools/tool-registry dissoc dummy-tool-name))
+
+      (tools/register-tool dummy-tool-name
+                           :description "A dummy tool that multiplies its input by 2."
+                           :parameters [:x]
+                           :parameter-example "x: number"
+                           :function (fn [x] (* 2 x)))
+      (is (= (tools/execute-tool dummy-tool-name 21) 42) "Tool should execute and return correct result."))
+
+    (testing "Cleaning up the dummy tool"
+      (swap! tools/tool-registry dissoc dummy-tool-name)
+      (is (nil? (get @tools/tool-registry dummy-tool-name)) "Dummy tool should be removed from registry.")
+      
+      ;; Restore original tool if one was temporarily removed
+      (when @original-registry-value
+        (tools/register-tool dummy-tool-name
+                             :description (:description @original-registry-value)
+                             :parameters (:parameters @original-registry-value)
+                             :parameter-example (:parameter-example @original-registry-value)
+                             :function (:function @original-registry-value))))
+    
+    (testing "Executing a non-existent tool"
+        (is (thrown? clojure.lang.ExceptionInfo (tools/execute-tool "non-existent-tool" 123))
+            "Executing a non-existent tool should throw an ExceptionInfo."))))
+
+;; To run these tests, you would typically use a test runner.
+;; For example, in a REPL:
+;; (require 'clj-llm-agent.tests)
+;; (clojure.test/run-tests 'clj-llm-agent.tests)

--- a/tools.clj
+++ b/tools.clj
@@ -1,0 +1,111 @@
+(ns clj-llm-agent.tools
+  (:require [clojure.string :as str]
+            [clojure.java.io :as io]))
+
+(defonce tool-registry (atom {})) ; Use defonce to avoid re-initializing if the ns is reloaded
+
+(defn register-tool
+  "Register a tool NAME with metadata and FUNCTION."
+  [name & {:keys [description parameters parameter-example function] :as tool-data}]
+  (swap! tool-registry assoc name (assoc tool-data :name name)))
+
+(defn list-tools
+  "Return a list of registered tools with metadata."
+  []
+  (vals @tool-registry))
+
+(defn execute-tool
+  "Execute tool NAME with ARGS, checking parameter counts."
+  [name & args]
+  (let [tool-data (get @tool-registry name)]
+    (if-not tool-data
+      (throw (ex-info (str "Tool " name " not found") {:tool-name name}))
+      (let [func (:function tool-data)
+            expected-params (:parameters tool-data)
+            actual-args args]
+        (if-not (= (count expected-params) (count actual-args))
+          (throw (ex-info (str "Tool " name " expected " (count expected-params) " args but got " (count actual-args))
+                          {:tool-name name
+                           :expected (count expected-params)
+                           :actual (count actual-args)}))
+          (apply func actual-args))))))
+
+(defmacro define-tool
+  "Convenience macro to register a tool.
+  Example: (define-tool "my-tool"
+             "Does something cool."
+             [:arg1 :arg2]
+             "arg1: string, arg2: number"
+             (fn [arg1 arg2] (str arg1 "-" arg2)))"
+  [name description parameters parameter-example function-body]
+  `(register-tool ~name
+                  :description ~description
+                  :parameters ~parameters
+                  :parameter-example ~parameter-example
+                  :function ~function-body))
+
+;; Placeholder for helper-summarize - requires Gemini client
+(defn helper-summarize [text]
+  (let [prompt (str "Summarize the following text:\n" text)]
+    (println "--- Summarize Tool (Placeholder) ---")
+    (println prompt)
+    (println "--- End Summarize Tool ---")
+    (str "Summary of: '" text "' (placeholder - requires Gemini integration)")))
+
+(register-tool "tool-summarize"
+               :description "Summarize text using Gemini (placeholder)."
+               :parameters [:text]
+               :parameter-example "text: string"
+               :function helper-summarize)
+
+;; Placeholder for tool-search-web - requires Tavily client
+(defn helper-search-web [query]
+  (println "--- Search Web Tool (Placeholder) ---")
+  (println (str "Query: " query))
+  (println "--- End Search Web Tool ---")
+  (str "Search results for: '" query "' (placeholder - requires Tavily integration)"))
+
+(register-tool "tool-search-web"
+               :description "Search the web with Tavily (placeholder)."
+               :parameters [:query]
+               :parameter-example "query: string"
+               :function helper-search-web)
+
+;; Predefined helper functions and their registrations
+(defn helper-read-directory
+  "List files in DIR excluding hidden or backup files."
+  [directory-path-str]
+  (let [dir (io/file directory-path-str)]
+    (if (.exists dir)
+      (if (.isDirectory dir)
+        (->> (.listFiles dir)
+             (map #(.getName %))
+             (remove (fn [n]
+                       (or (.startsWith n ".") ; hidden files
+                           (.startsWith n "#") ; Emacs backup files
+                           (.endsWith n "~")))) ; other backup files
+             vec)
+        (throw (ex-info (str "Not a directory: " directory-path-str) {:path directory-path-str})))
+      (throw (ex-info (str "Directory not found: " directory-path-str) {:path directory-path-str})))))
+
+(register-tool "tool-read-directory"
+               :description "Reads the contents of a directory."
+               :parameters [:directory-path]
+               :parameter-example "directory-path: string"
+               :function helper-read-directory)
+
+(defn helper-read-file
+  "Return the contents of FILE as a string, or error if missing."
+  [file-path-str]
+  (let [file (io/file file-path-str)]
+    (if (.exists file)
+      (if (.isFile file)
+        (slurp file)
+        (throw (ex-info (str "Not a regular file: " file-path-str) {:path file-path-str})))
+      (throw (ex-info (str "File not found: " file-path-str) {:path file-path-str})))))
+
+(register-tool "tool-read-file"
+               :description "Reads the contents of a file."
+               :parameters [:file-path]
+               :parameter-example "file-path: string"
+               :function helper-read-file)


### PR DESCRIPTION
This commit introduces a Clojure version of the existing Common Lisp LLM agent framework. The Clojure implementation mirrors the structure and functionality of the original Lisp code.

Key changes include:

-   **Core Logic Translation**:
    -   `package.clj`: Defines the main namespace.
    -   `context.clj`: Context management using atoms and maps.
    -   `tools.clj`: Tool registration/execution with placeholders for
        external API calls (Gemini, Tavily).
    -   `agent_generic.clj`: Core agent record, multimethods for LLM
        calls, and conversation logic.
    -   `agent_gemini.clj`: Gemini-specific agent implementation with
        a placeholder for LLM calls.

-   **Testing**:
    -   `test.clj`: A manual script for demonstrating agent functionality.
    -   `tests/tests.clj`: Unit tests for context and tools using
        `clojure.test`.

-   **Project Files**:
    -   `deps.edn`: Manages Clojure dependencies and test aliases.
    -   `.gitignore`: Updated with Clojure/Java specific patterns.
    -   `README.md`: Extended with a "Clojure Version" section,
        explaining how to run the new code.

The Clojure version provides a comparable agent framework, ready for further development and integration of actual LLM and tool backends.